### PR TITLE
Update dockerfile to latest RabbitMQ version

### DIFF
--- a/rabbitmq/Dockerfile
+++ b/rabbitmq/Dockerfile
@@ -7,10 +7,10 @@ ENV chocolateyUseWindowsCompression false
 RUN iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1')); \
     choco install -y curl;
 
-RUN choco install -y erlang
-ENV ERLANG_SERVICE_MANAGER_PATH="C:\Program Files\erl8.2\erts-8.2\bin"
-RUN choco install -y rabbitmq
-ENV RABBITMQ_SERVER="C:\Program Files\RabbitMQ Server\rabbitmq_server-3.6.5"
+RUN choco install -y erlang --version 19.3
+ENV ERLANG_SERVICE_MANAGER_PATH="C:\Program Files\erl8.3\erts-8.3\bin"
+RUN choco install -y rabbitmq --version 3.6.10
+ENV RABBITMQ_SERVER="C:\Program Files\RabbitMQ Server\rabbitmq_server-3.6.10"
 
 ENV RABBITMQ_CONFIG_FILE="c:\rabbitmq"
 COPY rabbitmq.config C:/
@@ -23,5 +23,5 @@ EXPOSE 5672
 EXPOSE 5671
 EXPOSE 15672
 
-WORKDIR C:/Program\ Files/RabbitMQ\ Server/rabbitmq_server-3.6.5/sbin
+WORKDIR C:/Program\ Files/RabbitMQ\ Server/rabbitmq_server-3.6.10/sbin
 CMD .\rabbitmq-server.bat

--- a/rabbitmq/Dockerfile
+++ b/rabbitmq/Dockerfile
@@ -24,4 +24,4 @@ EXPOSE 5671
 EXPOSE 15672
 
 WORKDIR C:/Program\ Files/RabbitMQ\ Server/rabbitmq_server-3.6.10/sbin
-CMD .\rabbitmq-server.bat
+CMD for($i=1; $i -le 60; $i++) { .\rabbitmq-server.bat; Start-Sleep -s 1; }

--- a/rabbitmq/build.ps1
+++ b/rabbitmq/build.ps1
@@ -28,7 +28,7 @@ Param(
 }
 
 $image="rabbitmq"
-$build="3.6.5"
+$build="3.6.10"
 
 invoke-exe -cmd docker -args "build -t spring2/${image}:$build ."
 invoke-exe -cmd docker -args "tag spring2/${image}:$build spring2/${image}:latest"


### PR DESCRIPTION
I tried to run this docker image in a Kubernetes cluster, but encountered some issues because it used an older version (3.6.5) of RabbitMQ. The issue is documented [here](https://github.com/rabbitmq/rabbitmq-server/issues/890/).
Updating the docker image to the latest RabbitMQ version resolves this issue and allows deployment in Kubernetes.